### PR TITLE
Define library.properties includes property

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Archer Cloud panels provide you an easy and fast way to visualize and 
 category=Communication
 url=https://github.com/byteAgenten/ArduinoArcherPanelClient
 architectures=*
-includes=
+includes=ArduinoArcherPanelClient.h


### PR DESCRIPTION
Previously this property was left blank which caused Sketch > Include Library > ArduinoArcherPanelClient to add the following line to the sketch:
```
#include <>
```
After this change, doing so will cause the following line to be added:
```
#include <ArduinoArcherPanelClient.h>
```