### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,25 +6,25 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-ArduinoArcherPanelClient    KEYWORD1
-AuthenticationCommand   KEYWORD1
-AuthenticationResponseEvent KEYWORD1
-ElementClickEvent   KEYWORD1
-KeepAliveCommand    KEYWORD1
-ObserverPanelsCommand   KEYWORD1
-PanelCommand    KEYWORD1
-PanelEvent  KEYWORD1
-SetVariableCommand  KEYWORD1
-UserValueInputEvent KEYWORD1
+ArduinoArcherPanelClient	KEYWORD1
+AuthenticationCommand	KEYWORD1
+AuthenticationResponseEvent	KEYWORD1
+ElementClickEvent	KEYWORD1
+KeepAliveCommand	KEYWORD1
+ObserverPanelsCommand	KEYWORD1
+PanelCommand	KEYWORD1
+PanelEvent	KEYWORD1
+SetVariableCommand	KEYWORD1
+UserValueInputEvent	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-toJson  KEYWORD2
-jsonToEvent KEYWORD2
-isAuthenticated KEYWORD2
-isTypeOf    KEYWORD2
+toJson	KEYWORD2
+jsonToEvent	KEYWORD2
+isAuthenticated	KEYWORD2
+isTypeOf	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords